### PR TITLE
Extra static derivs & fix travis rst-lint issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - sudo apt-get update
   - sudo apt-get install libmagic-dev libwebp-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 install:
   - sudo apt-get update
   - sudo apt-get install libmagic-dev libwebp-dev
-  - pip install iiif_validator coveralls pep8 pep257 restructuredtext_lint testfixtures
+  - pip install iiif_validator coveralls pep8 pep257 testfixtures
   - python setup.py install
 script:
   # use -n with run_validate.sh because I can't get the netpbm tests going on Travis yet

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,11 @@
 iiif changelog
 ==============
 
-2017-??-?? v1.0.3
+2017-03-20 v1.0.3
 
+- Add --extra parameter to iiif_static.py
 - Drop python 3.3 from tests, add python 3.6
+- Drop rst-lint from travis tests as no longer works on python 2.6
 
 2017-01-19 v1.0.2
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,20 +1,28 @@
 iiif changelog
 ==============
 
+2017-??-?? v1.0.3
+
+- Drop python 3.3 from tests, add python 3.6
+
 2017-01-19 v1.0.2
+
 - Handle 16bit TIFF with PIL manipulators
 - Support IIIF Authentication API v1.0
 
 2016-05-24 v1.0.1
+
 - Tweak pypi install
 
 2016-05-24 v1.0.0
+
 - Change to 1.x.x version as core codebase stable
 - Make IIIF Image API v2.1 the default (although not all features implemented)
 - Improvements for PIL manipulator (thanks @jgreidy)
 - Extended info.profile to complex profiles for 2.x Image Information 
 
 2016-04-22 v0.6.1
+
 - Now works with python 2.6, 2.7, 3.3, 3.4 and 3.5
 - Static tile generation supports both use of canonical size syntax for
   OpenSeadragon >= 1.2.1, and the old syntax for earlier versions
@@ -22,6 +30,7 @@ iiif changelog
 - Use logging instead of print in iiif.static
 
 2015-08-17 v0.6.0
+
 - Refactor manipulators for easier testing
 - Improve test coverage of PIL manipulator
 - Fix static files tile sizes (thanks @edsu)
@@ -31,30 +40,37 @@ iiif changelog
   region, and trial authentication support
 
 2015-02-14 v0.5.1
+
 - Valentines edition, wishing Amy and Ian lasting happiness
 - PIL and netpbm manipulators support IIIF Image API v2.0 and v1.1 at level 2
 - Improved test coverage using IIIF validator
   (https://pypi.python.org/pypi/iiif-validator)
 
 2014-11-11 v0.5.0
+
 - Supports IIIF Image API v2.0 and v1.1 at level 1
 
 2014-09-17 v0.4.2
+
 - Tidy tests, checked against python 2.6 and 2.7
 - Still needs work to support recently released IIIF Image API v2.0
 
 2014-04-28 v0.4.1
+
 - Add iiif_static.py as script for pypi install
 
 2014-04-28 v0.4.0
+
 - Aim to support IIIF Image API v1.1 and v2.0
 - Added generation of static file tiles for OpenSeadragon
 - Included demo for OpenSeadragon with static file tiles
 
 2014-04-22 v0.3.0
+
 - Change pypi package name from i3f to iiif
 
 2013-05-21 v0.2.0
+
 - Reorganized, aims for IIIF Image API v1.0
   (http://www-sul.stanford.edu/iiif/image-api/)
 - PIL library support (IIIFManipulatorPIL) and null tested, the netpbm
@@ -65,4 +81,5 @@ iiif changelog
 - Add GPL
 
 2012-03-21 v0.1.0
+
 - First stab at IIIF Image API v0.1

--- a/README
+++ b/README
@@ -30,7 +30,7 @@ Installation
 ------------
 
 The library, test server, static file generator are all designed to
-work with Python 2.6, 2.7, 3.4 and 3.5. Manual installation is 
+work with Python 2.6, 2.7, 3.4, 3.5 and 3.6. Manual installation is 
 necessary to get the demonstration documentation and examples.
 
 **Automatic installation from PyPI**

--- a/iiif/_version.py
+++ b/iiif/_version.py
@@ -1,2 +1,2 @@
 """Version number for this IIIF Image API library."""
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/iiif_static.py
+++ b/iiif_static.py
@@ -39,6 +39,9 @@ def main():
                  help="Identifier for the image that will be used in place of the filename "
                       "(minus extension). Notes that this option cannot be used if more than "
                       "one image file is to be processed")
+    p.add_option('--extra', '-e', action='append', default=[],
+                 help="Extra request parameters to be used to generate static files, may be "
+                      "repeated (e.g. '/full/90,/0/default.jpg' for a 90 wide thumnail)")
     p.add_option('--write-html', action='store', default=None,
                  help="Write HTML page to the specified directory using the 'identifier.html' "
                       "as the filename. HTML will launch OpenSeadragon for this image and to "
@@ -98,7 +101,8 @@ def main():
                             api_version=opt.api_version, dryrun=opt.dryrun,
                             prefix=opt.prefix, osd_version=opt.osd_version,
                             generator=opt.generator,
-                            max_image_pixels=opt.max_image_pixels)
+                            max_image_pixels=opt.max_image_pixels,
+                            extras=opt.extra)
             for source in sources:
                 # File or directory (or neither)?
                 if (os.path.isfile(source) or opt.generator):

--- a/pypi_upload.md
+++ b/pypi_upload.md
@@ -10,15 +10,16 @@ Putting up a new version
 ------------------------
 
   0. Bump version number working branch in iiif/_version.py and check CHANGES.md is up to date
-  1. Check all tests good (python setup.py test; py.test)
-  2. Check code is up-to-date with github version
-  3. Check out master and merge in working branch
-  4. Check all tests good (python setup.py test; py.test)
-  5. Make sure master README has correct travis-ci and coveralls icon links for master branch (?branch=master)
-  6. Check branches are as expected (git branch -a)
-  7. Check local build and version reported OK (python setup.py build; sudo python setup.py install)
-  8. Check iiif_testserver.py correctly starts server and is accessible from <http://localhost:8000>
-  9. If all checks out OK, tag and push the new version to github with something like:
+  1. Check format of README: `rst-lint README`
+  2. Check all tests good (python setup.py test; py.test)
+  3. Check code is up-to-date with github version
+  4. Check out master and merge in working branch
+  5. Check all tests good (python setup.py test; py.test)
+  6. Make sure master README has correct travis-ci and coveralls icon links for master branch (?branch=master)
+  7. Check branches are as expected (git branch -a)
+  8. Check local build and version reported OK (python setup.py build; sudo python setup.py install)
+  9. Check iiif_testserver.py correctly starts server and is accessible from <http://localhost:8000>
+  10. If all checks out OK, tag and push the new version to github with something like:
 
     ```
     git tag -n1
@@ -29,6 +30,6 @@ Putting up a new version
     python setup.py sdist upload
     ```
 
-  10. Then check on PyPI at <https://pypi.python.org/pypi/iiif>
-  11. Finally, back on working branch start new version number by editing `iiif/_version.py` and `CHANGES.md`
+  11. Then check on PyPI at <https://pypi.python.org/pypi/iiif>
+  12. Finally, back on working branch start new version number by editing `iiif/_version.py` and `CHANGES.md`
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,4 +5,3 @@
 python setup.py test
 pep8 --ignore=E501 *.py iiif/*.py iiif/generators/*.py tests/*.py tests/testlib/*.py
 pep257 *.py iiif/*.py iiif/generators/*.py tests/*.py tests/testlib/*.py
-rst-lint README

--- a/setup.py
+++ b/setup.py
@@ -65,9 +65,9 @@ setup(
                  "Programming Language :: Python",
                  "Programming Language :: Python :: 2.6",
                  "Programming Language :: Python :: 2.7",
-                 "Programming Language :: Python :: 3.3",
                  "Programming Language :: Python :: 3.4",
                  "Programming Language :: Python :: 3.5",
+                 "Programming Language :: Python :: 3.6",
                  "Topic :: Internet :: WWW/HTTP",
                  "Topic :: Multimedia :: Graphics :: Graphics Conversion",
                  "Topic :: Software Development :: "


### PR DESCRIPTION
  * Add --extra parameter to iiif_static.py
  * Drop python 3.3 from tests, add python 3.6
  * Drop rst-lint from travis tests as no longer works on python 2.6 (starting from v1.0.0 released earlier this year, requires OrderedDict and other things without workaround code for 2.6 :-( https://github.com/twolfson/restructuredtext-lint/blob/master/CHANGELOG.rst )