### PR TITLE
Fix travis build for python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: python
 python:
-  - "2.7"
-  - "3.6"
-  - "3.7"
-  - "3.8"
+  - 2.7
+  - 3.6
+  - 3.7
+  - 3.8
+  - pypy
+  - pypy3
 install:
   - sudo apt-get update
   - sudo apt-get install libmagic-dev libwebp-dev
-  - pip install 'setuptools<45' iiif_validator coveralls pep8 pep257 testfixtures
+  - pip install setuptools==44
+  - pip install iiif_validator coveralls pep8 pep257 testfixtures
   - python setup.py install
 script:
   - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 install:
   - sudo apt-get update
   - sudo apt-get install libmagic-dev libwebp-dev
-  - pip install Flask==1.0.4
+  - pip install Flask==1.1.0
   - pip install iiif_validator coveralls pep8 pep257 testfixtures
   - python setup.py install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
 install:
   - sudo apt-get update
   - sudo apt-get install libmagic-dev libwebp-dev
+  # having current Flask or pinning in setup.py breaks travis 2.7 build -- FIXME!
+  - pip install Flask=1.1.0
   - pip install iiif_validator coveralls pep8 pep257 testfixtures
   - python setup.py install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 python:
   - 2.7
   - 3.6
@@ -9,7 +10,7 @@ python:
 install:
   - sudo apt-get update
   - sudo apt-get install libmagic-dev libwebp-dev
-  - pip install setuptools==44
+  - pip install Flask==1.0.4
   - pip install iiif_validator coveralls pep8 pep257 testfixtures
   - python setup.py install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 install:
   - sudo apt-get update
   - sudo apt-get install libmagic-dev libwebp-dev
-  - pip install iiif_validator coveralls pep8 pep257 testfixtures
+  - pip install 'setuptools<45' iiif_validator coveralls pep8 pep257 testfixtures
   - python setup.py install
 script:
   - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install libmagic-dev libwebp-dev
   # having current Flask or pinning in setup.py breaks travis 2.7 build -- FIXME!
-  - pip install Flask=1.1.0
+  - pip install Flask==1.1.0
   - pip install iiif_validator coveralls pep8 pep257 testfixtures
   - python setup.py install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - sudo apt-get update
   - sudo apt-get install libmagic-dev libwebp-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ python:
   - 3.6
   - 3.7
   - 3.8
-  - pypy
-  - pypy3
 install:
   - sudo apt-get update
   - sudo apt-get install libmagic-dev libwebp-dev
-  - pip install Flask==1.1.0
   - pip install iiif_validator coveralls pep8 pep257 testfixtures
   - python setup.py install
 script:

--- a/README
+++ b/README
@@ -32,7 +32,7 @@ Installation
 ------------
 
 The library, test server, static file generator are all designed to
-work with Python 2.7, 3.5 and 3.6. Manual installation is
+work with Python 2.7 and recent versions of Python 3. Manual installation is
 necessary to get the demonstration documentation and examples.
 
 **Automatic installation from PyPI**

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,9 @@ setup(
                  "Programming Language :: Python :: 2",
                  "Programming Language :: Python :: 2.7",
                  "Programming Language :: Python :: 3",
-                 "Programming Language :: Python :: 3.5",
                  "Programming Language :: Python :: 3.6",
+                 "Programming Language :: Python :: 3.7",
+                 "Programming Language :: Python :: 3.8",
                  "Topic :: Internet :: WWW/HTTP",
                  "Topic :: Multimedia :: Graphics :: Graphics Conversion",
                  "Topic :: Software Development :: "

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     install_requires=[
         "Pillow",
         "python-magic",
-        "Flask",
+        "Flask==1.1.0",  # Travis on Python2.7 isn't happy with 1.1.1 -- FIXME
         "ConfigArgParse>=0.13.0"
     ],
     test_suite="tests",

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     install_requires=[
         "Pillow",
         "python-magic",
-        "Flask==1.1.0",  # Travis on Python2.7 isn't happy with 1.1.1 -- FIXME
+        "Flask",
         "ConfigArgParse>=0.13.0"
     ],
     test_suite="tests",


### PR DESCRIPTION
Not sure how long I should try to keep the python 2.7 build going but since everything does work fine with 2.7 it seems sad to jettison it too soon. The problem seems to be fixed by pinning Flask to 1.1.0 in `.travis.xml` ... not quite sure why but doing this in `setup.py` doesn't work.

For issue, see e.g. https://travis-ci.org/github/zimeon/iiif/builds/652833032

```
Running Jinja2-3.0.0a1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-LOzJxO/Jinja2-3.0.0a1/egg-dist-tmp-uKe9ch
Traceback (most recent call last):
  File "setup.py", line 92, in <module>
    'coverage': Coverage,
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/opt/python/2.7.15/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/opt/python/2.7.15/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/opt/python/2.7.15/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/command/install.py", line 67, in run
    self.do_egg_install()
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/command/install.py", line 117, in do_egg_install
    cmd.run()
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 418, in run
    self.easy_install(spec, not self.no_deps)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 660, in easy_install
    return self.install_item(None, spec, tmpdir, deps, True)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 707, in install_item
    self.process_distribution(spec, dist, deps)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 752, in process_distribution
    [requirement], self.local_index, self.easy_install
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pkg_resources/__init__.py", line 782, in resolve
    replace_conflicting=replace_conflicting
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1065, in best_match
    return self.obtain(req, installer)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1077, in obtain
    return installer(requirement)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 679, in easy_install
    return self.install_item(spec, dist.location, tmpdir, deps)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 705, in install_item
    dists = self.install_eggs(spec, download, tmpdir)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 890, in install_eggs
    return self.build_and_install(setup_script, setup_base)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 1158, in build_and_install
    self.run_setup(setup_script, setup_base, args)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 1144, in run_setup
    run_setup(setup_script, args)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/sandbox.py", line 253, in run_setup
    raise
  File "/opt/python/2.7.15/lib/python2.7/contextlib.py", line 35, in __exit__
    self.gen.throw(type, value, traceback)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/sandbox.py", line 195, in setup_context
    yield
  File "/opt/python/2.7.15/lib/python2.7/contextlib.py", line 35, in __exit__
    self.gen.throw(type, value, traceback)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/sandbox.py", line 166, in save_modules
    saved_exc.resume()
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/sandbox.py", line 141, in resume
    six.reraise(type, exc, self._tb)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/sandbox.py", line 154, in save_modules
    yield saved
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/sandbox.py", line 195, in setup_context
    yield
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/sandbox.py", line 250, in run_setup
    _execfile(setup_script, ns)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/sandbox.py", line 45, in _execfile
    exec(code, globals, locals)
  File "/tmp/easy_install-LOzJxO/Jinja2-3.0.0a1/setup.py", line 6, in <module>
    
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/setuptools/sandbox.py", line 419, in _open
    return _open(path, mode, *args, **kw)
TypeError: 'encoding' is an invalid keyword argument for this function
The command "python setup.py install" failed and exited with 1 during .
```